### PR TITLE
Add SwiftUI OCR app skeleton

### DIFF
--- a/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/Models/PhotoData.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import PhotosUI
+
+enum PostStatus {
+    case none
+    case success
+    case failure
+}
+
+struct PhotoData: Identifiable {
+    let id = UUID()
+    let item: PhotosPickerItem
+    var image: UIImage?
+    var ocrText: String?
+    var postStatus: PostStatus = .none
+
+    init(item: PhotosPickerItem) {
+        self.item = item
+    }
+
+    mutating func loadImage(completion: @escaping (Bool) -> Void) {
+        Task {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let uiImage = UIImage(data: data) {
+                await MainActor.run {
+                    self.image = uiImage
+                    completion(true)
+                }
+            } else {
+                await MainActor.run {
+                    completion(false)
+                }
+            }
+        }
+    }
+}

--- a/OCRScreenShotApp/Networking/GoogleFormPoster.swift
+++ b/OCRScreenShotApp/Networking/GoogleFormPoster.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+class GoogleFormPoster {
+    static let shared = GoogleFormPoster()
+
+    // Replace these entry IDs with the ones from your Google Form
+    private let formURL = URL(string: "https://docs.google.com/forms/d/e/1FAIpQLSdw27tlBBJBhYsLwG_6jCz8_WINxRMPk2jyaiqqgQ6v-7_-Lg/formResponse")!
+    private let tierEntry = "entry.123456"
+    private let waveEntry = "entry.234567"
+    private let timeEntry = "entry.345678"
+    private let coinsEntry = "entry.456789"
+    private let cellsEntry = "entry.567890"
+    private let shardsEntry = "entry.678901"
+
+    func post(fields: OCRResultFields, completion: @escaping (Bool) -> Void) {
+        var request = URLRequest(url: formURL)
+        request.httpMethod = "POST"
+        let body = [
+            tierEntry: fields.tier,
+            waveEntry: fields.wave,
+            timeEntry: fields.realTime,
+            coinsEntry: fields.coins,
+            cellsEntry: fields.cells,
+            shardsEntry: fields.shards
+        ]
+        .compactMap { key, value in
+            guard !value.isEmpty else { return nil }
+            return "\(key)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        }
+        .joined(separator: "&")
+        request.httpBody = body.data(using: .utf8)
+
+        let task = URLSession.shared.dataTask(with: request) { _, response, error in
+            guard let http = response as? HTTPURLResponse, error == nil else {
+                completion(false)
+                return
+            }
+            completion(http.statusCode == 200)
+        }
+        task.resume()
+    }
+}

--- a/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -1,0 +1,62 @@
+import UIKit
+import Vision
+
+struct OCRResultFields {
+    var tier: String = ""
+    var wave: String = ""
+    var realTime: String = ""
+    var coins: String = ""
+    var cells: String = ""
+    var shards: String = ""
+}
+
+class OCRProcessor {
+    static let shared = OCRProcessor()
+
+    func recognizeText(in image: UIImage, completion: @escaping (String) -> Void) {
+        guard let cgImage = image.cgImage else {
+            completion("")
+            return
+        }
+
+        let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        let request = VNRecognizeTextRequest { request, error in
+            guard error == nil else {
+                completion("")
+                return
+            }
+            let text = request.results?
+                .compactMap { ($0 as? VNRecognizedTextObservation)?.topCandidates(1).first?.string }
+                .joined(separator: "\n") ?? ""
+            completion(text)
+        }
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try requestHandler.perform([request])
+            } catch {
+                completion("")
+            }
+        }
+    }
+
+    func extractFields(from text: String) -> OCRResultFields {
+        func match(for label: String) -> String {
+            if let range = text.range(of: "\(label\)\s*([0-9:]+)", options: .regularExpression) {
+                return String(text[range]).replacingOccurrences(of: label, with: "").trimmingCharacters(in: .whitespaces)
+            }
+            return ""
+        }
+
+        var result = OCRResultFields()
+        result.tier = match(for: "tier")
+        result.wave = match(for: "wave")
+        result.realTime = match(for: "real time")
+        result.coins = match(for: "coins earned")
+        result.cells = match(for: "cells earned")
+        result.shards = match(for: "reroll shards earned")
+        return result
+    }
+}

--- a/OCRScreenShotApp/OCRScreenShotAppApp.swift
+++ b/OCRScreenShotApp/OCRScreenShotAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct OCRScreenShotAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/OCRScreenShotApp/Views/ContentView.swift
+++ b/OCRScreenShotApp/Views/ContentView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import PhotosUI
+
+struct ContentView: View {
+    @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var photoItems: [PhotoData] = []
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if photoItems.isEmpty {
+                    Text("Select screenshots to process")
+                }
+                List(photoItems) { item in
+                    HStack {
+                        if let image = item.image {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFit()
+                                .frame(width: 100, height: 100)
+                        }
+                        VStack(alignment: .leading) {
+                            Text(item.ocrText ?? "No OCR yet")
+                            switch item.postStatus {
+                            case .none:
+                                Text("Pending")
+                                    .foregroundColor(.secondary)
+                            case .success:
+                                Text("Uploaded")
+                                    .foregroundColor(.green)
+                            case .failure:
+                                Text("Failed")
+                                    .foregroundColor(.red)
+                            }
+                        }
+                    }
+                }
+                PhotosPicker(
+                    selection: $selectedItems,
+                    maxSelectionCount: nil,
+                    matching: .images,
+                    photoLibrary: .shared()) {
+                    Text("Pick Photos")
+                }
+                .onChange(of: selectedItems) { _ in
+                    handleResults(selectedItems)
+                }
+                .padding()
+            }
+            .navigationTitle("OCR Screen Shot")
+        }
+    }
+
+    private func handleResults(_ items: [PhotosPickerItem]) {
+        for item in items {
+            let data = PhotoData(item: item)
+            photoItems.append(data)
+            loadImage(for: data)
+        }
+        selectedItems.removeAll()
+    }
+
+    private func loadImage(for photoData: PhotoData) {
+        guard let index = photoItems.firstIndex(where: { $0.id == photoData.id }) else { return }
+        photoItems[index].loadImage { success in
+            if success {
+                OCRProcessor.shared.recognizeText(in: photoItems[index].image!) { text in
+                    photoItems[index].ocrText = text
+                    let fields = OCRProcessor.shared.extractFields(from: text)
+                    GoogleFormPoster.shared.post(fields: fields) { result in
+                        DispatchQueue.main.async {
+                            photoItems[index].postStatus = result ? .success : .failure
+                        }
+                    }
+                }
+            } else {
+                photoItems[index].postStatus = .failure
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# ocr-screen-shot-app
+# OCR Screenshot App (iOS)
+
+This sample project demonstrates how to pick screenshots from the photo library, perform OCR on each image, extract game related stats and upload the results to a Google Form. Each screenshot is listed with a success or failure indicator after uploading.
+
+## Features
+
+- Select one or more images using `PhotosPicker`.
+- Perform text recognition using the Vision framework.
+- Parse recognized text for the following fields:
+  - **tier**
+  - **wave**
+  - **real time (duration)**
+  - **coins earned**
+  - **cells earned**
+  - **reroll shards earned**
+- Send extracted values to the provided Google Form.
+- Display a list of processed screenshots with an indicator for upload success or failure.
+
+## Setup
+
+1. Open the `OCRScreenShotApp` folder in Xcode.
+2. Replace the placeholder entry IDs in `GoogleFormPoster.swift` with the actual field entry IDs from your Google Form.
+3. Build and run on an iOS device running iOS 16 or later.
+
+This repository does not include an Xcode project file. Simply add these Swift source files to a new SwiftUI iOS project.
+


### PR DESCRIPTION
## Summary
- create a SwiftUI example for an OCR screenshot app
- add models and OCR/Text extraction helpers
- post extracted values to a Google Form
- document how to use the sample code

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_683a5389c6c8832ebe6b68865c24847a