### PR TITLE
Fix regex string escaping

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -44,7 +44,7 @@ class OCRProcessor {
 
     func extractFields(from text: String) -> OCRResultFields {
         func match(for label: String) -> String {
-            if let range = text.range(of: "\(label\)\s*([0-9:]+)", options: .regularExpression) {
+            if let range = text.range(of: "\(label)\\s*([0-9:]+)", options: .regularExpression) {
                 return String(text[range]).replacingOccurrences(of: label, with: "").trimmingCharacters(in: .whitespaces)
             }
             return ""


### PR DESCRIPTION
## Summary
- correct the regular expression string in `OCRProcessor`

## Testing
- `swift -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a5cde5c70832e9e54e8dcb374550d