### PR TITLE
Fix async image loading compile error

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -62,10 +62,13 @@ struct ContentView: View {
 
     private func loadImage(for photoData: PhotoData) {
         guard let index = photoItems.firstIndex(where: { $0.id == photoData.id }) else { return }
-        photoItems[index].loadImage { success in
+        Task {
+            let success = await photoItems[index].loadImage()
             if success {
                 OCRProcessor.shared.recognizeText(in: photoItems[index].image!) { text in
-                    photoItems[index].ocrText = text
+                    DispatchQueue.main.async {
+                        photoItems[index].ocrText = text
+                    }
                     let fields = OCRProcessor.shared.extractFields(from: text)
                     GoogleFormPoster.shared.post(fields: fields) { result in
                         DispatchQueue.main.async {
@@ -74,7 +77,9 @@ struct ContentView: View {
                     }
                 }
             } else {
-                photoItems[index].postStatus = .failure
+                DispatchQueue.main.async {
+                    photoItems[index].postStatus = .failure
+                }
             }
         }
     }

--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
@@ -18,19 +18,15 @@ struct PhotoData: Identifiable {
         self.item = item
     }
 
-    mutating func loadImage(completion: @escaping (Bool) -> Void) {
-        Task {
-            if let data = try? await item.loadTransferable(type: Data.self),
-               let uiImage = UIImage(data: data) {
-                await MainActor.run {
-                    self.image = uiImage
-                    completion(true)
-                }
-            } else {
-                await MainActor.run {
-                    completion(false)
-                }
+    mutating func loadImage() async -> Bool {
+        if let data = try? await item.loadTransferable(type: Data.self),
+           let uiImage = UIImage(data: data) {
+            await MainActor.run {
+                self.image = uiImage
             }
+            return true
+        } else {
+            return false
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor `PhotoData.loadImage` to use async/await instead of escaping closure
- update call sites to handle new async function

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_683a6b1a94b8832ea185a08cad177fc9