### PR TITLE
Fix deprecated onChange usage

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -42,8 +42,8 @@ struct ContentView: View {
                     photoLibrary: .shared()) {
                     Text("Pick Photos")
                 }
-                .onChange(of: selectedItems) { _ in
-                    handleResults(selectedItems)
+                .onChange(of: selectedItems) { _, newValue in
+                    handleResults(newValue)
                 }
                 .padding()
             }


### PR DESCRIPTION
## Summary
- update `ContentView` to use the iOS 17 `onChange` two-parameter closure

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a6ca91440832eb8176e45086636cb