### PR TITLE
Implement photo grid with stats view

### DIFF
--- a/OCRScreenShotApp.xcodeproj/project.pbxproj
+++ b/OCRScreenShotApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
   1A2B3C4D5E6F7A0000000022 /* PhotoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A0000000012 /* PhotoData.swift */; };
   1A2B3C4D5E6F7A0000000023 /* GoogleFormPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A0000000013 /* GoogleFormPoster.swift */; };
   1A2B3C4D5E6F7A0000000024 /* OCRProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A0000000014 /* OCRProcessor.swift */; };
+  1A2B3C4D5E6F7A0000000026 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A0000000016 /* StatsView.swift */; };
   1A2B3C4D5E6F7A0000000025 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 1A2B3C4D5E6F7A0000000015 /* Info.plist */; };
 /* End PBXBuildFile section */
 
@@ -20,6 +21,7 @@
   1A2B3C4D5E6F7A0000000012 /* PhotoData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoData.swift; sourceTree = "<group>"; };
   1A2B3C4D5E6F7A0000000013 /* GoogleFormPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleFormPoster.swift; sourceTree = "<group>"; };
   1A2B3C4D5E6F7A0000000014 /* OCRProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRProcessor.swift; sourceTree = "<group>"; };
+  1A2B3C4D5E6F7A0000000016 /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Views/StatsView.swift; sourceTree = "<group>"; };
   1A2B3C4D5E6F7A0000000015 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
   1A2B3C4D5E6F7A0000000040 /* OCRScreenShotApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = OCRScreenShotApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -33,6 +35,7 @@
       1A2B3C4D5E6F7A0000000012 /* PhotoData.swift */,
       1A2B3C4D5E6F7A0000000013 /* GoogleFormPoster.swift */,
       1A2B3C4D5E6F7A0000000014 /* OCRProcessor.swift */,
+      1A2B3C4D5E6F7A0000000016 /* StatsView.swift */,
       1A2B3C4D5E6F7A0000000015 /* Info.plist */,
     );
     path = OCRScreenShotApp;
@@ -127,6 +130,7 @@
       1A2B3C4D5E6F7A0000000022 /* PhotoData.swift in Sources */,
       1A2B3C4D5E6F7A0000000023 /* GoogleFormPoster.swift in Sources */,
       1A2B3C4D5E6F7A0000000024 /* OCRProcessor.swift in Sources */,
+      1A2B3C4D5E6F7A0000000026 /* StatsView.swift in Sources */,
     );
     runOnlyForDeploymentPostprocessing = 0;
   };

--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -24,26 +24,18 @@ struct ContentView: View {
                     }
                     Spacer()
                 } else {
-                    List(photoItems) { item in
-                        HStack {
-                            if let image = item.image {
-                                Image(uiImage: image)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 100, height: 100)
-                            }
-                            VStack(alignment: .leading) {
-                                Text(item.ocrText ?? "No OCR yet")
-                                switch item.postStatus {
-                                case .none:
-                                    Text("Pending")
-                                        .foregroundColor(.secondary)
-                                case .success:
-                                    Text("Uploaded")
-                                        .foregroundColor(.green)
-                                case .failure:
-                                    Text("Failed")
-                                        .foregroundColor(.red)
+                    ScrollView {
+                        let columns = [GridItem(.adaptive(minimum: 100), spacing: 2)]
+                        LazyVGrid(columns: columns, spacing: 2) {
+                            ForEach($photoItems) { $item in
+                                if let image = item.image {
+                                    NavigationLink(destination: StatsView(photoData: $item)) {
+                                        Image(uiImage: image)
+                                            .resizable()
+                                            .scaledToFill()
+                                            .frame(minWidth: 100, minHeight: 100)
+                                            .clipped()
+                                    }
                                 }
                             }
                         }

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct StatsView: View {
+    @Binding var photoData: PhotoData
+
+    private var fields: OCRResultFields {
+        if let text = photoData.ocrText {
+            return OCRProcessor.shared.extractFields(from: text)
+        }
+        return OCRResultFields()
+    }
+
+    private var statusText: String {
+        switch photoData.postStatus {
+        case .none:
+            return "Pending"
+        case .success:
+            return "Uploaded"
+        case .failure:
+            return "Failed"
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            if let image = photoData.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Status: \(statusText)")
+                    .font(.headline)
+
+                if !fields.tier.isEmpty { Text("Tier: \(fields.tier)") }
+                if !fields.wave.isEmpty { Text("Wave: \(fields.wave)") }
+                if !fields.realTime.isEmpty { Text("Real Time: \(fields.realTime)") }
+                if !fields.coins.isEmpty { Text("Coins: \(fields.coins)") }
+                if !fields.cells.isEmpty { Text("Cells: \(fields.cells)") }
+                if !fields.shards.isEmpty { Text("Shards: \(fields.shards)") }
+
+                if let text = photoData.ocrText {
+                    Text("\nRecognized Text:")
+                        .font(.headline)
+                    Text(text)
+                        .font(.footnote)
+                        .padding(.top, 2)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Stats")
+    }
+}
+


### PR DESCRIPTION
## Summary
- show uploaded screenshots in a `LazyVGrid` on the index page
- tap a screenshot to navigate to `StatsView`
- add `StatsView` for viewing OCR results and upload status
- register `StatsView.swift` in the Xcode project

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a6ec8e82c832eb3e6a9caceb3ad0c