### PR TITLE
Trim text before Battle Report during OCR parsing

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -70,7 +70,16 @@ class OCRProcessor {
         )
         var results: [(String, String)] = []
 
-        text
+        // Remove any text before "Battle Report" to avoid extraneous lines
+        let trimmedText: String
+        if let range = text.range(of: "battle report", options: .caseInsensitive) {
+            trimmedText = String(text[range.upperBound...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            trimmedText = text
+        }
+
+        trimmedText
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .forEach { line in


### PR DESCRIPTION
## Summary
- clean OCR text by removing everything up to and including the "Battle Report" header

## Testing
- `swiftc -parse OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift && echo "swiftc parse succeeded"`

------
https://chatgpt.com/codex/tasks/task_e_683b08cddd84832ebb1948d1d6da8957