### PR TITLE
Implement combat section trimming

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -61,6 +61,26 @@ class OCRProcessor {
         return result
     }
 
+    /// Remove the text section that starts with "Combat" and continues until
+    /// the last line before a line containing any digits.
+    private func removeCombatSection(from text: String) -> String {
+        var lines = text.components(separatedBy: .newlines)
+        guard let startIndex = lines.firstIndex(where: { $0.range(of: "combat", options: .caseInsensitive) != nil }) else {
+            return text
+        }
+
+        var endIndex = startIndex
+        for i in (startIndex + 1)..<lines.count {
+            if lines[i].rangeOfCharacter(from: .decimalDigits) != nil {
+                break
+            }
+            endIndex = i
+        }
+
+        lines.removeSubrange(startIndex...endIndex)
+        return lines.joined(separator: "\n")
+    }
+
     /// Parse generic key/value pairs from OCR'd text where each line contains a
     /// label on the left and a value on the right separated by whitespace.
     func parsePairs(from text: String) -> [(label: String, value: String)] {
@@ -79,7 +99,8 @@ class OCRProcessor {
             trimmedText = text
         }
 
-        trimmedText
+        let cleanedText = removeCombatSection(from: trimmedText)
+        cleanedText
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .forEach { line in


### PR DESCRIPTION
## Summary
- trim the block of text between "Combat" and the first numeric line
- parse pairs after removing the combat section

## Testing
- `swift --version`
- `swiftformat --version` *(fails: command not found)*
- `swiftlint version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b0b43f7e0832e8fe3a37ffe198c13