### PR TITLE
Simplify OCR pair parsing

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -11,6 +11,12 @@ struct OCRResultFields {
     var shards: String = ""
 }
 
+/// Represents a unique label/value pair parsed from the OCR text.
+struct LabelValuePair: Hashable {
+    let label: String
+    let value: String
+}
+
 class OCRProcessor {
     static let shared = OCRProcessor()
 
@@ -84,11 +90,7 @@ class OCRProcessor {
     /// Parse generic key/value pairs from OCR'd text where each line contains a
     /// label on the left and a value on the right separated by whitespace.
     func parsePairs(from text: String) -> [(label: String, value: String)] {
-        let regex = try? NSRegularExpression(
-            pattern: "^(.+?)\\s+([0-9][0-9.,]*[A-Za-z]*)$",
-            options: [.anchorsMatchLines]
-        )
-        var results: [(String, String)] = []
+        var pairSet: Set<LabelValuePair> = []
 
         // Remove any text before "Battle Report" to avoid extraneous lines
         let trimmedText: String
@@ -104,36 +106,15 @@ class OCRProcessor {
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
+        let pairCount = min(11, lines.count / 2)
+        guard pairCount > 0 else { return [] }
 
-        // First attempt to parse label/value pairs that occur on the same line
-        for line in lines {
-            if let regex = regex,
-               let match = regex.firstMatch(in: line, range: NSRange(line.startIndex..<line.endIndex, in: line)),
-               match.numberOfRanges == 3,
-               let labelRange = Range(match.range(at: 1), in: line),
-               let valueRange = Range(match.range(at: 2), in: line) {
-                let label = String(line[labelRange])
-                let value = String(line[valueRange])
-                results.append((label, value))
-            } else if let range = line.range(of: "\\s+(\\S+)$", options: .regularExpression) {
-                let label = String(line[..<range.lowerBound])
-                let value = String(line[range.upperBound...])
-                results.append((label, value))
-            }
+        for i in 0..<pairCount {
+            let label = lines[i]
+            let value = lines[i + pairCount]
+            pairSet.insert(LabelValuePair(label: label, value: value))
         }
 
-        // If no pairs were detected, try pairing the first half of the lines
-        // with the second half. This handles cases where OCR reads two columns
-        // of labels and values as separate line groups.
-        if results.isEmpty && !lines.isEmpty && lines.count % 2 == 0 {
-            let half = lines.count / 2
-            let labels = lines.prefix(half)
-            let values = lines.suffix(half)
-            if labels.count == values.count {
-                results = Array(zip(labels, values))
-            }
-        }
-
-        return results
+        return pairSet.map { ($0.label, $0.value) }
     }
 }


### PR DESCRIPTION
## Summary
- create `LabelValuePair` to support storing label/value tuples in a set
- drop complex regex parsing and pair up the first 11 lines with the following 11 lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683b105c5324832ea77a5253fa95aa11