### PR TITLE
Improve stats view and manual submission

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -79,7 +79,13 @@ struct ContentView: View {
                     let fields = OCRProcessor.shared.extractFields(from: text)
                     GoogleFormPoster.shared.post(fields: fields) { result in
                         DispatchQueue.main.async {
-                            photoItems[index].postStatus = result ? .success : .failure
+                            switch result {
+                            case .success:
+                                photoItems[index].postStatus = .success
+                            case .failure(let error):
+                                print("Google form submission error: \(error.localizedDescription)")
+                                photoItems[index].postStatus = .failure
+                            }
                         }
                     }
                 }

--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -90,7 +90,8 @@ class OCRProcessor {
     /// Parse generic key/value pairs from OCR'd text where each line contains a
     /// label on the left and a value on the right separated by whitespace.
     func parsePairs(from text: String) -> [(label: String, value: String)] {
-        var pairSet: Set<LabelValuePair> = []
+        var results: [(String, String)] = []
+        var seenLabels = Set<String>()
 
         // Remove any text before "Battle Report" to avoid extraneous lines
         let trimmedText: String
@@ -106,15 +107,17 @@ class OCRProcessor {
             .components(separatedBy: .newlines)
             .map { $0.trimmingCharacters(in: .whitespaces) }
             .filter { !$0.isEmpty }
-        let pairCount = min(11, lines.count / 2)
+        let pairCount = lines.count / 2
         guard pairCount > 0 else { return [] }
 
         for i in 0..<pairCount {
             let label = lines[i]
             let value = lines[i + pairCount]
-            pairSet.insert(LabelValuePair(label: label, value: value))
+            guard !seenLabels.contains(label) else { continue }
+            seenLabels.insert(label)
+            results.append((label, value))
         }
 
-        return pairSet.map { ($0.label, $0.value) }
+        return results
     }
 }


### PR DESCRIPTION
## Summary
- deduplicate OCR stat keys in `OCRProcessor`
- update `GoogleFormPoster` to return a Result for error logging
- handle new Result type in `ContentView`
- add a submit button with spinner & success/failure states in `StatsView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683b16f3b5f4832eabdb86eae062d23b