### PR TITLE
Bug fixes for stats parsing and Google submission

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -76,18 +76,8 @@ struct ContentView: View {
                     DispatchQueue.main.async {
                         photoItems[index].ocrText = text
                     }
-                    let fields = OCRProcessor.shared.extractFields(from: text)
-                    GoogleFormPoster.shared.post(fields: fields) { result in
-                        DispatchQueue.main.async {
-                            switch result {
-                            case .success:
-                                photoItems[index].postStatus = .success
-                            case .failure(let error):
-                                print("Google form submission error: \(error.localizedDescription)")
-                                photoItems[index].postStatus = .failure
-                            }
-                        }
-                    }
+                    // Do not auto-submit to Google after OCR. Submission will
+                    // happen from the Stats screen.
                 }
             } else {
                 DispatchQueue.main.async {

--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -117,7 +117,7 @@ class OCRProcessor {
             seenLabels.insert(label)
             results.append((label, value))
         }
-
-        return results
+        // Only include the first 11 unique label/value pairs
+        return Array(results.prefix(11))
     }
 }


### PR DESCRIPTION
## Summary
- limit displayed stats rows to the first 11
- stop Google form submission when an image is uploaded; submission now happens from the Stats screen only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683b186ebd68832e897dd2956ad98d41