### PR TITLE
Add StatsModel for parsed stats

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Models/StatsModel.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/StatsModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct StatsModel {
+    var gameTime: String = ""
+    var realTime: String = ""
+    var tier: String = ""
+    var wave: String = ""
+    var killedBy: String = ""
+    var coinsEarned: String = ""
+    var cashEarned: String = ""
+    var interestEarned: String = ""
+    var gemBlocksTapped: String = ""
+    var cellsEarned: String = ""
+    var rerollShardsEarned: String = ""
+
+    init(pairs: [(String, String)]) {
+        let dict = Dictionary(uniqueKeysWithValues: pairs.map { ($0.0.lowercased(), $0.1) })
+        self.gameTime = StatsModel.normalizeTime(dict["game time"] ?? "")
+        self.realTime = StatsModel.normalizeTime(dict["real time"] ?? "")
+        self.tier = dict["tier"] ?? ""
+        self.wave = dict["wave"] ?? ""
+        self.killedBy = dict["killed by"] ?? ""
+        self.coinsEarned = dict["coins earned"] ?? ""
+        self.cashEarned = dict["cash earned"] ?? ""
+        self.interestEarned = dict["interest earned"] ?? ""
+        self.gemBlocksTapped = dict["gem blocks tapped"] ?? ""
+        self.cellsEarned = dict["cells earned"] ?? ""
+        self.rerollShardsEarned = dict["reroll shards earned"] ?? ""
+    }
+
+    private static func normalizeTime(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        let pattern = "^(\\d+)h\\s*(\\d+)m\\s*([0-9]{1,3})(?:s)?$"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: trimmed, options: [], range: NSRange(location: 0, length: trimmed.utf16.count)) else {
+            return value
+        }
+        let hoursRange = Range(match.range(at: 1), in: trimmed)!
+        let minutesRange = Range(match.range(at: 2), in: trimmed)!
+        var seconds = String(trimmed[Range(match.range(at: 3), in: trimmed)!])
+
+        if seconds.count == 3 && seconds.hasSuffix("5") {
+            seconds = String(seconds.prefix(2))
+        }
+        return "\(trimmed[hoursRange])h \(trimmed[minutesRange])m \(seconds)s"
+    }
+}
+

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -12,6 +12,33 @@ struct StatsView: View {
         return []
     }
 
+    private var statsModel: StatsModel? {
+        if let text = photoData.ocrText {
+            let pairs = OCRProcessor.shared.parsePairs(from: text)
+            return StatsModel(pairs: pairs)
+        }
+        return nil
+    }
+
+    private var displayPairs: [(String, String)] {
+        if let model = statsModel {
+            return [
+                ("Game Time", model.gameTime),
+                ("Real Time", model.realTime),
+                ("Tier", model.tier),
+                ("Wave", model.wave),
+                ("Killed By", model.killedBy),
+                ("Coins Earned", model.coinsEarned),
+                ("Cash Earned", model.cashEarned),
+                ("Interest Earned", model.interestEarned),
+                ("Gem Blocks Tapped", model.gemBlocksTapped),
+                ("Cells Earned", model.cellsEarned),
+                ("Reroll Shards Earned", model.rerollShardsEarned)
+            ]
+        }
+        return parsedPairs
+    }
+
     private var extractedFields: OCRResultFields {
         if let text = photoData.ocrText {
             return OCRProcessor.shared.extractFields(from: text)
@@ -29,7 +56,7 @@ struct StatsView: View {
 
             VStack(alignment: .leading, spacing: 8) {
 
-                if !parsedPairs.isEmpty {
+                if !displayPairs.isEmpty {
                     Text("Stats:")
                         .font(.headline)
                         .padding(.top, 8)
@@ -40,8 +67,8 @@ struct StatsView: View {
                         }
                         Divider().gridCellColumns(2)
 
-                        ForEach(parsedPairs.indices, id: \.self) { index in
-                            let pair = parsedPairs[index]
+                        ForEach(displayPairs.indices, id: \.self) { index in
+                            let pair = displayPairs[index]
                             GridRow {
                                 Text(pair.0)
                                 Text(pair.1)


### PR DESCRIPTION
## Summary
- create `StatsModel` to structure parsed OCR data
- normalize time values within the model
- use the new model in `StatsView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683b2b9c40d8832e8fb3b3307f04b87f