### PR TITLE
Add screenshot cropping

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
@@ -18,11 +18,37 @@ struct PhotoData: Identifiable {
         self.item = item
     }
 
+    // Cropping ratios based on a 1206x2622 reference screenshot.
+    // Adjust these values if the UI layout changes.
+    private let cropLeftRatio: CGFloat = 0.0
+    private let cropTopRatio: CGFloat = 460.0 / 2622.0
+    private let cropRightRatio: CGFloat = 1.0
+    private let cropBottomRatio: CGFloat = 2170.0 / 2622.0
+
+    /// Crop the given image using the ratios above. The ratios are applied
+    /// to the pixel dimensions of the image so this works for different
+    /// screenshot resolutions while keeping the region of interest.
+    private func crop(_ image: UIImage) -> UIImage {
+        let pixelWidth = CGFloat(image.cgImage?.width ?? Int(image.size.width))
+        let pixelHeight = CGFloat(image.cgImage?.height ?? Int(image.size.height))
+
+        let rect = CGRect(x: cropLeftRatio * pixelWidth,
+                          y: cropTopRatio * pixelHeight,
+                          width: (cropRightRatio - cropLeftRatio) * pixelWidth,
+                          height: (cropBottomRatio - cropTopRatio) * pixelHeight)
+
+        guard let cgImage = image.cgImage?.cropping(to: rect) else {
+            return image
+        }
+        return UIImage(cgImage: cgImage, scale: image.scale, orientation: image.imageOrientation)
+    }
+
     mutating func loadImage() async -> Bool {
         if let data = try? await item.loadTransferable(type: Data.self),
            let uiImage = UIImage(data: data) {
+            let cropped = crop(uiImage)
             await MainActor.run {
-                self.image = uiImage
+                self.image = cropped
             }
             return true
         } else {


### PR DESCRIPTION
## Summary
- crop selected images to the area between the battle report header and the combat section
- return the cropped image so index and stats views only display the clipped portion

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683b2e9aa67c832e85543200e7a2e78d