### PR TITLE
Implement manual Google sign-in

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Networking/GoogleAuthManager.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Networking/GoogleAuthManager.swift
@@ -1,13 +1,18 @@
 import Foundation
-import GoogleSignIn
+import AuthenticationServices
 import UIKit
 
-class GoogleAuthManager: ObservableObject {
+class GoogleAuthManager: NSObject, ObservableObject {
     static let shared = GoogleAuthManager()
-    @Published private(set) var user: GIDGoogleUser?
 
-    private init() {
-        restorePreviousSignIn()
+    @Published private(set) var idToken: String?
+
+    private let tokenKey = "GoogleIDToken"
+    private var session: ASWebAuthenticationSession?
+    private var anchorProvider: AnchorProvider?
+
+    private override init() {
+        idToken = UserDefaults.standard.string(forKey: tokenKey)
     }
 
     func signIn(presenting viewController: UIViewController) {
@@ -15,37 +20,65 @@ class GoogleAuthManager: ObservableObject {
             print("CLIENT_ID missing from Info.plist")
             return
         }
-        let config = GIDConfiguration(clientID: clientID)
-        GIDSignIn.sharedInstance.configuration = config
-        GIDSignIn.sharedInstance.signIn(withPresenting: viewController) { [weak self] result, error in
-            if let error = error {
+
+        let scheme = "com.googleusercontent.apps.\(clientID)"
+        let redirectURI = "\(scheme):/oauthredirect"
+        var components = URLComponents(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "response_type", value: "id_token"),
+            URLQueryItem(name: "scope", value: "openid email"),
+            URLQueryItem(name: "nonce", value: UUID().uuidString)
+        ]
+        guard let url = components.url else { return }
+
+        anchorProvider = AnchorProvider(viewController: viewController)
+        session = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { [weak self] callbackURL, error in
+            guard let self = self else { return }
+            if let callbackURL, let fragment = callbackURL.fragment,
+               let token = Self.extractToken(from: fragment) {
+                DispatchQueue.main.async {
+                    self.idToken = token
+                    UserDefaults.standard.set(token, forKey: self.tokenKey)
+                }
+            } else if let error = error {
                 print("Google Sign-In error: \(error.localizedDescription)")
-                return
             }
-            self?.user = result?.user
         }
+        session?.presentationContextProvider = anchorProvider
+        session?.prefersEphemeralWebBrowserSession = true
+        session?.start()
     }
 
     func signOut() {
-        GIDSignIn.sharedInstance.signOut()
-        user = nil
-    }
-
-    private func restorePreviousSignIn() {
-        GIDSignIn.sharedInstance.restorePreviousSignIn { [weak self] user, error in
-            if let user = user {
-                self?.user = user
-            } else if let error = error {
-                print("Restore sign-in failed: \(error.localizedDescription)")
-            }
-        }
+        idToken = nil
+        UserDefaults.standard.removeObject(forKey: tokenKey)
     }
 
     var isSignedIn: Bool {
-        user != nil
+        idToken != nil
     }
 
-    var idToken: String? {
-        user?.idToken?.tokenString
+    private static func extractToken(from fragment: String) -> String? {
+        for pair in fragment.split(separator: "&") {
+            let parts = pair.split(separator: "=")
+            if parts.count == 2 && parts[0] == "id_token" {
+                return String(parts[1])
+            }
+        }
+        return nil
+    }
+}
+
+private class AnchorProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    weak var viewController: UIViewController?
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        viewController?.view.window ?? ASPresentationAnchor()
     }
 }


### PR DESCRIPTION
## Summary
- remove dependency on GoogleSignIn package
- implement Google OAuth using `ASWebAuthenticationSession`
- persist received id token in `UserDefaults`

## Testing
- `swiftc` build *(fails: no such module 'AuthenticationServices')*

------
https://chatgpt.com/codex/tasks/task_e_683c683ed9ac832eb01fe8b2da85c6aa