### PR TITLE
Allow manual editing of parsed stats

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -4,6 +4,8 @@ struct StatsView: View {
     @Binding var photoData: PhotoData
 
     @State private var isPosting = false
+    @State private var isEditing = false
+    @State private var editPairs: [(String, String)] = []
 
     private var parsedPairs: [(String, String)] {
         if let text = photoData.ocrText,
@@ -60,7 +62,9 @@ struct StatsView: View {
 
             VStack(alignment: .leading, spacing: 8) {
 
-                if !displayPairs.isEmpty {
+                if isEditing {
+                    editingView
+                } else if !displayPairs.isEmpty {
                     Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
                         ForEach(displayPairs.indices, id: \.self) { index in
                             let pair = displayPairs[index]
@@ -72,7 +76,11 @@ struct StatsView: View {
                         }
                     }
 
-                    submitButton
+                    HStack {
+                        submitButton
+                        Button("Edit Stats") { startEditing() }
+                            .padding(.leading)
+                    }
                 } else if let text = photoData.ocrText,
                           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     Text("\nRecognized Text:")
@@ -80,6 +88,8 @@ struct StatsView: View {
                     Text(text)
                         .font(.footnote)
                         .padding(.top, 2)
+                    Button("Edit Stats") { startEditing() }
+                        .padding(.top, 8)
                 } else {
                     Text("Invalid image")
                         .font(.headline)
@@ -88,6 +98,46 @@ struct StatsView: View {
             }
             .padding()
         }
+        .onAppear {
+            if statsModel == nil,
+               let text = photoData.ocrText,
+               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                startEditing()
+            }
+        }
+    }
+
+    private var editingView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+                ForEach(editPairs.indices, id: \.self) { index in
+                    GridRow {
+                        TextField("Label", text: $editPairs[index].0)
+                        TextField("Value", text: $editPairs[index].1)
+                    }
+                    Divider().gridCellColumns(2)
+                }
+            }
+            HStack {
+                Button("Save") { saveEdits() }
+                Button("Cancel") { isEditing = false }
+            }
+            .padding(.top, 8)
+        }
+    }
+
+    private func startEditing() {
+        if editPairs.isEmpty {
+            editPairs = !displayPairs.isEmpty ? displayPairs : parsedPairs
+        }
+        isEditing = true
+    }
+
+    private func saveEdits() {
+        let text = editPairs.map { "\($0.0)\n\($0.1)" }.joined(separator: "\n")
+        photoData.ocrText = text
+        editPairs.removeAll()
+        isEditing = false
     }
 
     private var submitButton: some View {


### PR DESCRIPTION
## Summary
- enable editing of parsed stats when OCR results fail
- show editable grid of labels and values
- save corrections back to OCR text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683b46f68db4832ebe74a16fd8ba0d93