### PR TITLE
Move sign-in button to index

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -1,13 +1,18 @@
 import SwiftUI
 import PhotosUI
+import UIKit
 
 struct ContentView: View {
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var photoItems: [PhotoData] = []
+    @StateObject private var authManager = GoogleAuthManager.shared
 
     var body: some View {
         NavigationView {
             VStack {
+                if !authManager.isSignedIn {
+                    signInButton
+                }
                 if photoItems.isEmpty {
                     Spacer()
                     PhotosPicker(
@@ -56,6 +61,17 @@ struct ContentView: View {
             }
             .navigationTitle("OCR Screen Shot")
         }
+    }
+
+    private var signInButton: some View {
+        Button("Sign in with Google", action: signIn)
+            .buttonStyle(.borderedProminent)
+    }
+
+    private func signIn() {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController else { return }
+        authManager.signIn(presenting: root)
     }
 
     private func handleResults(_ items: [PhotosPickerItem]) {

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct StatsView: View {
     @Binding var photoData: PhotoData
@@ -74,10 +73,6 @@ struct StatsView: View {
                         }
                     }
 
-                    if !authManager.isSignedIn {
-                        signInButton
-                    }
-
                     submitButton
                 } else if let text = photoData.ocrText,
                           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -117,17 +112,6 @@ struct StatsView: View {
         .tint(tintColor)
         .disabled(isPosting || photoData.postStatus != .none || !authManager.isSignedIn || statsModel?.hasParsingError == true)
         .padding(.top, 8)
-    }
-
-    private var signInButton: some View {
-        Button("Sign in with Google", action: signIn)
-            .buttonStyle(.borderedProminent)
-    }
-
-    private func signIn() {
-        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-              let root = scene.windows.first(where: { $0.isKeyWindow })?.rootViewController else { return }
-        authManager.signIn(presenting: root)
     }
 
     private var tintColor: Color {


### PR DESCRIPTION
## Summary
- remove sign in button from `StatsView`
- add sign in button and logic to `ContentView`

## Testing
- `swiftc -parse OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift`
- `swiftc -parse OCRScreenShotApp/OCRScreenShotApp/ContentView.swift`
- `swiftc -parse OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift OCRScreenShotApp/OCRScreenShotApp/ContentView.swift > /tmp/compile_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_683c757b518c832e9e3cb4e6289851d8