### PR TITLE
Display tier analysis on index

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -5,6 +5,54 @@ struct ContentView: View {
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var photoItems: [PhotoData] = []
 
+    private var tierAnalysis: (coins: String, cells: String, shards: String)? {
+        let models = photoItems.compactMap { $0.statsModel }
+        guard !models.isEmpty else { return nil }
+
+        func intValue(_ value: String) -> Int {
+            return Int(value.filter { $0.isNumber }) ?? 0
+        }
+
+        func bestTier(for keyPath: KeyPath<StatsModel, String>) -> String {
+            let groups = Dictionary(grouping: models, by: { $0.tier })
+            var bestTier = ""
+            var best = 0
+            for (tier, items) in groups {
+                let total = items.reduce(0) { $0 + intValue($1[keyPath: keyPath]) }
+                if total > best {
+                    best = total
+                    bestTier = tier
+                }
+            }
+            return bestTier
+        }
+
+        return (
+            coins: bestTier(for: \StatsModel.coinsEarned),
+            cells: bestTier(for: \StatsModel.cellsEarned),
+            shards: bestTier(for: \StatsModel.rerollShardsEarned)
+        )
+    }
+
+    @ViewBuilder
+    private var analysisView: some View {
+        if let analysis = tierAnalysis {
+            VStack(spacing: 4) {
+                Text("Tier Effectiveness")
+                    .font(.headline)
+                HStack {
+                    Text("Coins: \(analysis.coins)")
+                    Spacer()
+                    Text("Cells: \(analysis.cells)")
+                    Spacer()
+                    Text("Reroll: \(analysis.shards)")
+                }
+                .font(.subheadline)
+            }
+            .padding(.bottom)
+        }
+    }
+
     var body: some View {
         NavigationView {
             VStack {
@@ -52,6 +100,7 @@ struct ContentView: View {
                         handleResults(selectedItems)
                     }
                     .padding()
+                    analysisView
                 }
             }
             .navigationTitle("OCR Screen Shot")
@@ -76,6 +125,8 @@ struct ContentView: View {
                     OCRProcessor.shared.recognizeText(in: data.image!) { text in
                         DispatchQueue.main.async {
                             photoItems[index].ocrText = text
+                            let pairs = OCRProcessor.shared.parsePairs(from: text)
+                            photoItems[index].statsModel = StatsModel(pairs: pairs)
                         }
                     }
                 } else {

--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
@@ -12,6 +12,7 @@ struct PhotoData: Identifiable {
     let item: PhotosPickerItem
     var image: UIImage?
     var ocrText: String?
+    var statsModel: StatsModel?
     var postStatus: PostStatus = .none
 
     init(item: PhotosPickerItem) {


### PR DESCRIPTION
## Summary
- store `StatsModel` in `PhotoData`
- compute a per-metric tier analysis of all loaded screenshots
- display "Tier Effectiveness" row at the bottom of the main screen

## Testing
- `swiftc -parse ./OCRScreenShotApp/OCRScreenShotApp/ContentView.swift`
- `swiftc -parse ./OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift`


------
https://chatgpt.com/codex/tasks/task_e_683b4cd1917c832ebd425de77dec67bd