### PR TITLE
Update title and reposition sign-in button

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -58,9 +58,6 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             VStack {
-                if !authManager.isSignedIn {
-                    signInButton
-                }
                 if photoItems.isEmpty {
                     Spacer()
                     PhotosPicker(
@@ -108,7 +105,14 @@ struct ContentView: View {
                     analysisView
                 }
             }
-            .navigationTitle("OCR Screen Shot")
+            .navigationTitle("Tower Analysis")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !authManager.isSignedIn {
+                        signInButton
+                    }
+                }
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OCR Screenshot App (iOS)
+# Tower Analysis (iOS)
 
 This project is pure vibe coding an iOS App on OpenAI Codex. Minimal programming done by me directly aside from some XCode debugging.
 


### PR DESCRIPTION
## Summary
- rename the app title to **Tower Analysis**
- show the Google sign-in button in the navigation bar
- update README to match new app name

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_683c788294e4832e9c7032934ea90b1d