### PR TITLE
Fix analysis view layout on main screen

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -92,20 +92,22 @@ struct ContentView: View {
                                 }
                             }
                         }
+
+                        PhotosPicker(
+                            selection: $selectedItems,
+                            maxSelectionCount: nil,
+                            matching: .images,
+                            photoLibrary: .shared()
+                        ) {
+                            Text("Add Photos")
+                        }
+                        .onChange(of: selectedItems) { _ in
+                            handleResults(selectedItems)
+                        }
+                        .padding()
+
+                        analysisView
                     }
-                    PhotosPicker(
-                        selection: $selectedItems,
-                        maxSelectionCount: nil,
-                        matching: .images,
-                        photoLibrary: .shared()
-                    ) {
-                        Text("Add Photos")
-                    }
-                    .onChange(of: selectedItems) { _ in
-                        handleResults(selectedItems)
-                    }
-                    .padding()
-                    analysisView
                 }
             }
             .navigationTitle("OCR Screen Shot")


### PR DESCRIPTION
## Summary
- fix layout so the Add Photos button and analysis view appear in scroll view

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683c78598f9c832ea835132bd0742dcf