### PR TITLE
Fix sign in button alignment

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -108,6 +108,7 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("Tower Analysis")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if !authManager.isSignedIn {


### PR DESCRIPTION
## Summary
- display the navigation bar title inline so the Google sign-in button lines up with the title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c7c12f060832ea180bda63912e960