### PR TITLE
Fix OCR parse timing

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -147,8 +147,6 @@ struct ContentView: View {
                     OCRProcessor.shared.recognizeText(in: data.image!) { text in
                         DispatchQueue.main.async {
                             photoItems[index].ocrText = text
-                            let pairs = OCRProcessor.shared.parsePairs(from: text)
-                            photoItems[index].statsModel = StatsModel(pairs: pairs)
                         }
                     }
                 } else {

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -19,13 +19,7 @@ struct StatsView: View {
     }
 
     private var statsModel: StatsModel? {
-        if let text = photoData.ocrText,
-           !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let pairs = OCRProcessor.shared.parsePairs(from: text)
-            guard !pairs.isEmpty else { return nil }
-            return StatsModel(pairs: pairs)
-        }
-        return nil
+        photoData.statsModel
     }
 
     private var displayPairs: [(String, String)] {
@@ -103,10 +97,16 @@ struct StatsView: View {
             .padding()
         }
         .onAppear {
-            if statsModel == nil,
+            if photoData.statsModel == nil,
                let text = photoData.ocrText,
                !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                startEditing()
+                let pairs = OCRProcessor.shared.parsePairs(from: text)
+                if !pairs.isEmpty {
+                    photoData.statsModel = StatsModel(pairs: pairs)
+                }
+                if photoData.statsModel == nil {
+                    startEditing()
+                }
             }
         }
     }
@@ -140,6 +140,7 @@ struct StatsView: View {
     private func saveEdits() {
         let text = editPairs.map { "\($0.0)\n\($0.1)" }.joined(separator: "\n")
         photoData.ocrText = text
+        photoData.statsModel = StatsModel(pairs: editPairs)
         editPairs.removeAll()
         isEditing = false
     }


### PR DESCRIPTION
## Summary
- delay OCR parsing until user opens stats view
- compute stats model when stats view appears and when editing is saved

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c7bf6059c832e9f380836b460a188