### PR TITLE
Separate analysis section with white background

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -47,11 +47,13 @@ struct ContentView: View {
             tierBox(label: "Best Reroll Tier", value: shards)
         }
         .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color.white)
     }
 
     var body: some View {
         NavigationView {
-            VStack {
+            VStack(spacing: 0) {
                 if photoItems.isEmpty {
                     Spacer()
                     PhotosPicker(
@@ -98,6 +100,7 @@ struct ContentView: View {
                         .padding()
                     }
                 }
+                analysisView
             }
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
@@ -111,9 +114,6 @@ struct ContentView: View {
                         signInButton
                     }
                 }
-            }
-            .safeAreaInset(edge: .bottom) {
-                analysisView
             }
         }
     }


### PR DESCRIPTION
## Summary
- add frame and white background to analysis view
- show analysis view as part of main layout instead of overlaying the photo grid

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_683c83e4d50c832eb1e134660e231dd4