### PR TITLE
Add divider and background to analysis footer

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -47,6 +47,14 @@ struct ContentView: View {
             tierBox(label: "Best Reroll Tier", value: shards)
         }
         .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(UIColor.systemBackground))
+        .overlay(
+            Rectangle()
+                .fill(Color.black)
+                .frame(height: 1),
+            alignment: .top
+        )
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- add a solid background and top divider to the analysis footer

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_683c8579cda0832e9a70740ad211b091