### PR TITLE
Fix Info.plist reference for Photo Library permissions

### DIFF
--- a/OCRScreenShotApp.xcodeproj/project.pbxproj
+++ b/OCRScreenShotApp.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
     isa = XCBuildConfiguration;
     buildSettings = {
       ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-      INFOPLIST_FILE = OCRScreenShotApp/Info.plist;
+      INFOPLIST_FILE = OCRScreenShotApp/OCRScreenShotApp/Info.plist;
       PRODUCT_BUNDLE_IDENTIFIER = com.example.OCRScreenShotApp;
       PRODUCT_NAME = $(TARGET_NAME);
       SWIFT_VERSION = 5.9;
@@ -163,7 +163,7 @@
     isa = XCBuildConfiguration;
     buildSettings = {
       ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-      INFOPLIST_FILE = OCRScreenShotApp/Info.plist;
+      INFOPLIST_FILE = OCRScreenShotApp/OCRScreenShotApp/Info.plist;
       PRODUCT_BUNDLE_IDENTIFIER = com.example.OCRScreenShotApp;
       PRODUCT_NAME = $(TARGET_NAME);
       SWIFT_VERSION = 5.9;


### PR DESCRIPTION
## Summary
- point Xcode project to the correct Info.plist so NSPhotoLibraryUsageDescription keys are read

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683c85f1c274832e81496e21988db38e