### PR TITLE
Prevent invalid stats from being saved

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
@@ -29,7 +29,11 @@ final class StatsDatabase: ObservableObject {
     }
 
     /// Add a new stats record to the database and persist the change.
+    ///
+    /// If the provided ``StatsModel`` contains a parsing error the entry is
+    /// ignored to prevent invalid data from polluting the history.
     func add(_ stats: StatsModel) {
+        guard !stats.hasParsingError else { return }
         entries.append(stats)
         save()
     }

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -172,12 +172,14 @@ struct StatsView: View {
         Button(action: addToDatabase) {
             if isAdded {
                 Text("Added \u{2705}")
+            } else if statsModel?.hasParsingError == true {
+                Text("Parsing error cannot add")
             } else {
                 Text("Add to Analysis Database")
             }
         }
         .buttonStyle(.bordered)
-        .disabled(isAdded || statsModel == nil)
+        .disabled(isAdded || statsModel == nil || statsModel?.hasParsingError == true)
         .padding(.top, 8)
     }
 
@@ -209,7 +211,7 @@ struct StatsView: View {
     }
 
     private func addToDatabase() {
-        guard let stats = statsModel else { return }
+        guard let stats = statsModel, !stats.hasParsingError else { return }
         StatsDatabase.shared.add(stats)
         isAdded = true
     }


### PR DESCRIPTION
## Summary
- safeguard StatsDatabase from saving models with parsing errors
- disable Add to Analysis Database when parsed stats are invalid

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683c8d906280832e954a6b4070c38021