### PR TITLE
Fix efficiency formatting

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -19,8 +19,9 @@ struct StatsView: View {
     private static let efficiencyFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 0
         formatter.minimumFractionDigits = 0
+        formatter.roundingMode = .floor
         return formatter
     }()
 


### PR DESCRIPTION
## Summary
- truncate efficiency values to integers in StatsView

## Testing
- `swiftc --version` *(fails: no swift installed)*

------
https://chatgpt.com/codex/tasks/task_e_683cf5476c88832eb32b830a4add12ed