### PR TITLE
Fix saving of cash and interest values

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -169,6 +169,17 @@ struct StatsView: View {
     }
 
     private func saveEdits() {
+        // Automatically prefix cash and interest values with "$" if missing
+        for index in editPairs.indices {
+            let label = editPairs[index].0
+            var value = editPairs[index].1.trimmingCharacters(in: .whitespaces)
+            if (label == "Cash Earned" || label == "Interest Earned") &&
+                !value.isEmpty && !value.hasPrefix("$") {
+                value = "$" + value
+            }
+            editPairs[index].1 = value
+        }
+
         let text = editPairs.map { "\($0.0)\n\($0.1)" }.joined(separator: "\n")
         photoData.ocrText = text
         photoData.statsModel = StatsModel(pairs: editPairs, photoDate: photoData.creationDate)


### PR DESCRIPTION
## Summary
- auto-prefix `$` when saving Cash or Interest

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683cf5f65ea0832ea6650967b3e08767