### PR TITLE
Add prominent edit buttons

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -151,7 +151,9 @@ struct StatsView: View {
             }
             HStack {
                 Button("Save") { saveEdits() }
-                Button("Cancel") { isEditing = false }
+                    .buttonStyle(.borderedProminent)
+                Button("Discard", role: .destructive) { isEditing = false }
+                    .buttonStyle(.bordered)
             }
             .padding(.top, 8)
         }


### PR DESCRIPTION
## Summary
- style edit screen save/discard buttons with iOS bordered styling

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683cf64475c8832ea4fd2030badf1b47