### PR TITLE
Format duration with commas

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -34,6 +34,15 @@ struct StatsView: View {
         return formatter
     }()
 
+    private static let durationFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        formatter.minimumFractionDigits = 0
+        formatter.roundingMode = .floor
+        return formatter
+    }()
+
     private var parsedPairs: [(String, String)] {
         if let text = photoData.ocrText,
            !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -56,7 +65,10 @@ struct StatsView: View {
             result.append(contentsOf: [
                 ("Game Time", model.gameTime),
                 ("Real Time", model.realTime),
-                ("Duration", String(format: "%.0f", model.duration)),
+                (
+                    "Duration",
+                    (Self.durationFormatter.string(from: NSNumber(value: model.duration)) ?? "0") + "s"
+                ),
                 ("Tier", model.tier),
                 ("Wave", model.wave),
                 ("Killed By", model.killedBy),


### PR DESCRIPTION
## Summary
- show duration in stats with commas and `s` suffix

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683cf93ea4ac832e950d726da728e117