### PR TITLE
Improve StatsView error handling

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -155,6 +155,8 @@ struct StatsView: View {
                 if photoData.statsModel == nil {
                     startEditing()
                 }
+            } else if photoData.statsModel?.hasParsingError == true {
+                startEditing()
             }
             checkIfAdded()
         }


### PR DESCRIPTION
## Summary
- automatically enter edit mode when viewing stats with parsing errors

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cff252858832ebc010e8fdb0c9dc5