### PR TITLE
Auto-switch tabs when errors resolved

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -150,7 +150,11 @@ struct ContentView: View {
     @ViewBuilder
     private func gridItem(for item: Binding<PhotoData>) -> some View {
         if !item.wrappedValue.isProcessing, let image = item.wrappedValue.image {
-            NavigationLink(destination: StatsView(photoData: item)) {
+            NavigationLink(destination: StatsView(photoData: item, onParseSuccess: {
+                if errorCount == 0 {
+                    selectedTab = .analyzed
+                }
+            })) {
                 ZStack(alignment: .bottomTrailing) {
                     Image(uiImage: image)
                         .resizable()

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 // Provides access to `StatsDatabase` for persisting stats locally
 struct StatsView: View {
     @Binding var photoData: PhotoData
+    var onParseSuccess: (() -> Void)? = nil
 
     @State private var isAdded = false
     @State private var isEditing = false
@@ -218,6 +219,9 @@ struct StatsView: View {
         photoData.statsModel = StatsModel(pairs: editPairs, photoDate: photoData.creationDate)
         editPairs.removeAll()
         isEditing = false
+        if photoData.statsModel?.hasParsingError == false {
+            onParseSuccess?()
+        }
     }
 
     private var analysisButton: some View {


### PR DESCRIPTION
## Summary
- add optional callback in `StatsView` triggered on successful parse
- call that callback when edits are saved without errors
- update `ContentView` to switch back to the Analyzed tab if no error items remain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683d02663398832e9fee0a05c189e88e