### PR TITLE
Auto-switch to analysis view after successful parse

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -150,7 +150,7 @@ struct ContentView: View {
     @ViewBuilder
     private func gridItem(for item: Binding<PhotoData>) -> some View {
         if !item.wrappedValue.isProcessing, let image = item.wrappedValue.image {
-            NavigationLink(destination: StatsView(photoData: item)) {
+            NavigationLink(destination: StatsView(photoData: item, onParseSuccess: { selectedTab = .analyzed })) {
                 ZStack(alignment: .bottomTrailing) {
                     Image(uiImage: image)
                         .resizable()

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 // Provides access to `StatsDatabase` for persisting stats locally
 struct StatsView: View {
     @Binding var photoData: PhotoData
+    /// Callback triggered when edited stats parse without errors
+    var onParseSuccess: () -> Void = {}
 
     @State private var isAdded = false
     @State private var isEditing = false
@@ -215,9 +217,13 @@ struct StatsView: View {
 
         let text = editPairs.map { "\($0.0)\n\($0.1)" }.joined(separator: "\n")
         photoData.ocrText = text
-        photoData.statsModel = StatsModel(pairs: editPairs, photoDate: photoData.creationDate)
+        let model = StatsModel(pairs: editPairs, photoDate: photoData.creationDate)
+        photoData.statsModel = model
         editPairs.removeAll()
         isEditing = false
+        if !model.hasParsingError {
+            onParseSuccess()
+        }
     }
 
     private var analysisButton: some View {


### PR DESCRIPTION
## Summary
- add `onParseSuccess` callback to `StatsView`
- switch to `Analyzed` tab after fixing an error

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683d02baf524832eb0005699afc83aeb