### PR TITLE
Remove tier label text

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -102,10 +102,10 @@ struct ContentView: View {
         let refresh = tierAnalysis?.refresh ?? "N/A"
 
         return HStack(spacing: 8) {
-            tierBox(label: "Best Coins Tier", value: coins)
-            tierBox(label: "Best Cells Tier", value: cells)
-            tierBox(label: "Best Reroll Tier", value: shards)
-            tierBox(label: "Refresh Tier", value: refresh)
+            tierBox(label: "Best Coins", value: coins)
+            tierBox(label: "Best Cells", value: cells)
+            tierBox(label: "Best Reroll", value: shards)
+            tierBox(label: "Refresh", value: refresh)
         }
         .padding()
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- restore stale indicator logic
- drop the word `Tier` from analysis labels

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683d08fa33b0832e83b480d408572af9