### PR TITLE
Implement auto add for stats

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -250,7 +250,14 @@ struct ContentView: View {
                             let model = StatsModel(pairs: pairs, photoDate: photoItems[index].creationDate)
                             photoItems[index].statsModel = model
                             photoItems[index].isProcessing = false
-                            photoItems[index].isAdded = StatsDatabase.shared.entries.contains(model)
+
+                            let alreadyAdded = StatsDatabase.shared.entries.contains(model)
+                            if !alreadyAdded && !model.hasParsingError {
+                                StatsDatabase.shared.add(model)
+                                photoItems[index].isAdded = true
+                            } else {
+                                photoItems[index].isAdded = alreadyAdded
+                            }
                         }
                     }
                 } else {

--- a/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
@@ -34,6 +34,7 @@ final class StatsDatabase: ObservableObject {
     /// ignored to prevent invalid data from polluting the history.
     func add(_ stats: StatsModel) {
         guard !stats.hasParsingError else { return }
+        guard !entries.contains(stats) else { return }
         entries.append(stats)
         save()
     }


### PR DESCRIPTION
## Summary
- auto-add stats once OCR processing completes
- avoid duplicate database entries

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_683d0dfe367c832ea14b4da8ab075b9c