### PR TITLE
Automatically add corrected entries to database

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -219,7 +219,10 @@ struct StatsView: View {
         photoData.statsModel = StatsModel(pairs: editPairs, photoDate: photoData.creationDate)
         editPairs.removeAll()
         isEditing = false
-        if photoData.statsModel?.hasParsingError == false {
+        if let stats = photoData.statsModel, stats.hasParsingError == false {
+            StatsDatabase.shared.add(stats)
+            isAdded = true
+            photoData.isAdded = true
             onParseSuccess?()
         }
     }


### PR DESCRIPTION
## Summary
- auto-add corrected stats to the local analysis database when the edit is valid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683d10491e14832e8ebdd6a85a0044ee