### PR TITLE
Add navigation to stats screen

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -184,17 +184,17 @@ struct ContentView: View {
             let columns = [GridItem(.adaptive(minimum: 100), spacing: 2)]
             let indices = filteredIndices()
             LazyVGrid(columns: columns, spacing: 2) {
-                ForEach(indices, id: \.self) { index in
-                    gridItem(for: $photoItems[index])
+                ForEach(indices, id: .self) { index in
+                    gridItem(for: $photoItems[index], index: index, indices: indices)
                 }
             }
         }
     }
 
     @ViewBuilder
-    private func gridItem(for item: Binding<PhotoData>) -> some View {
+    private func gridItem(for item: Binding<PhotoData>, index: Int, indices: [Int]) -> some View {
         if !item.wrappedValue.isProcessing, let image = item.wrappedValue.image {
-            NavigationLink(destination: StatsView(photoData: item, onParseSuccess: {
+            NavigationLink(destination: StatsView(photoItems: $photoItems, indices: indices, startIndex: indices.firstIndex(of: index) ?? 0, onParseSuccess: {
                 if errorCount == 0 {
                     selectedTab = .analyzed
                 }


### PR DESCRIPTION
## Summary
- add ability to move between analyzed items in `StatsView`
- update grid item navigation to supply indices and current position

## Testing
- `swiftc -dump-ast OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683d12e98910832e812bc706898796e7