### PR TITLE
Fix parse error in ContentView ForEach

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -184,7 +184,7 @@ struct ContentView: View {
             let columns = [GridItem(.adaptive(minimum: 100), spacing: 2)]
             let indices = filteredIndices()
             LazyVGrid(columns: columns, spacing: 2) {
-                ForEach(indices, id: .self) { index in
+                ForEach(indices, id: \.self) { index in
                     gridItem(for: $photoItems[index], index: index, indices: indices)
                 }
             }


### PR DESCRIPTION
## Summary
- fix `ForEach` id argument to use `\.self`

## Testing
- `swiftc -parse-as-library OCRScreenShotApp/OCRScreenShotApp/ContentView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683d17d0b6e4832e8d57b4b3738d7bb2