### PR TITLE
Add delete functionality

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/StatsDatabase.swift
@@ -47,4 +47,10 @@ final class StatsDatabase: ObservableObject {
         save()
         return true
     }
+
+    /// Remove the provided stats from the database and persist the change.
+    func remove(_ stats: StatsModel) {
+        entries.removeAll { $0 == stats }
+        save()
+    }
 }


### PR DESCRIPTION
## Summary
- add delete button on StatsView
- support deleting stats from database

## Testing
- `swift --version`
- `swiftc OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift -o /tmp/out` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683d1d7bab00832eb901049bb1022859