### PR TITLE
Fix time parsing regex to handle 0h/0m/0s

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift
@@ -51,8 +51,16 @@ class OCRProcessor {
 
     func extractFields(from text: String) -> OCRResultFields {
         func match(for label: String) -> String {
-            if let range = text.range(of: "\(label)\\s*([0-9:]+)", options: .regularExpression) {
-                return String(text[range]).replacingOccurrences(of: label, with: "").trimmingCharacters(in: .whitespaces)
+            // Values like "0h 0m 0s" can appear for the time fields. The
+            // previous regex only captured digits and colons which caused the
+            // letters to be dropped resulting in an invalid time string. This
+            // regex includes the possible "d", "h", "m" and "s" units along with
+            // digits, colons and whitespace so the full value is captured.
+            let pattern = "\(label)\\s*([0-9dhms:\\s]+)"
+            if let range = text.range(of: pattern, options: .regularExpression) {
+                return String(text[range])
+                    .replacingOccurrences(of: label, with: "")
+                    .trimmingCharacters(in: .whitespaces)
             }
             return ""
         }


### PR DESCRIPTION
## Summary
- handle h/m/s suffixes in OCRProcessor.regex to prevent invalid times

## Testing
- `swiftc -parse OCRScreenShotApp/OCRScreenShotApp/OCR/OCRProcessor.swift`

------
https://chatgpt.com/codex/tasks/task_e_683d28e40a64832eb81a6806329d84bf