### PR TITLE
Prevent duplicate editing and space buttons

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -133,7 +133,7 @@ struct StatsView: View {
 
                     HStack {
                         analysisButton
-                        if !isAdded {
+                        if !isAdded && !isDuplicate {
                             Button("Edit Stats") { startEditing() }
                                 .padding(.leading)
                         }
@@ -150,7 +150,7 @@ struct StatsView: View {
                     Text(text)
                         .font(.footnote)
                         .padding(.top, 2)
-                    if !isAdded {
+                    if !isAdded && !isDuplicate {
                         Button("Edit Stats") { startEditing() }
                             .padding(.top, 8)
                     }
@@ -170,13 +170,16 @@ struct StatsView: View {
                 if !pairs.isEmpty {
                     photoData.wrappedValue.statsModel = StatsModel(pairs: pairs, photoDate: photoData.wrappedValue.creationDate)
                 }
-                if photoData.wrappedValue.statsModel == nil {
+                checkIfAdded()
+                if photoData.wrappedValue.statsModel == nil && !isDuplicate {
                     startEditing()
                 }
-            } else if photoData.wrappedValue.statsModel?.hasParsingError == true {
-                startEditing()
+            } else {
+                checkIfAdded()
+                if photoData.wrappedValue.statsModel?.hasParsingError == true && !isDuplicate {
+                    startEditing()
+                }
             }
-            checkIfAdded()
         }
         .onChange(of: photoData.wrappedValue.statsModel) { _ in
             checkIfAdded()
@@ -212,6 +215,7 @@ struct StatsView: View {
             HStack {
                 Button("Save") { saveEdits() }
                     .buttonStyle(.borderedProminent)
+                Spacer()
                 Button("Discard", role: .destructive) { isEditing = false }
                     .buttonStyle(.bordered)
             }
@@ -220,6 +224,7 @@ struct StatsView: View {
     }
 
     private func startEditing() {
+        guard !isDuplicate else { return }
         if editPairs.isEmpty {
             if !displayPairs.isEmpty {
                 let nonEditable = ["Photo Date", "Duration", "Coin Efficiency", "Cell Efficiency", "Shard Efficiency"]


### PR DESCRIPTION
## Summary
- disallow editing of duplicate entries
- keep Save and Discard buttons at opposite ends when editing
- update onAppear logic to avoid entering edit mode for duplicates

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_683d291c6874832eae9215b50e2255fc