### PR TITLE
Fix crash when deleting last photo

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -297,8 +297,13 @@ struct StatsView: View {
         if let model = photoData.wrappedValue.statsModel {
             StatsDatabase.shared.remove(model)
         }
-        photoItems.remove(at: indices[currentIndex])
+        let index = indices[currentIndex]
         dismiss()
+        DispatchQueue.main.async {
+            if photoItems.indices.contains(index) {
+                photoItems.remove(at: index)
+            }
+        }
     }
 
     private func addToDatabase() {


### PR DESCRIPTION
## Summary
- fix index out-of-range when deleting the last screenshot in StatsView

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874173474e4832ea7ffbd0397b133bb