### PR TITLE
Fix discard action for error edits

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -212,7 +212,13 @@ struct StatsView: View {
             HStack {
                 Button("Save") { saveEdits() }
                     .buttonStyle(.borderedProminent)
-                Button("Discard", role: .destructive) { isEditing = false }
+                Button("Discard", role: .destructive) {
+                    if statsModel == nil || statsModel?.hasParsingError == true {
+                        deleteCurrent()
+                    } else {
+                        isEditing = false
+                    }
+                }
                     .buttonStyle(.bordered)
             }
             .padding(.top, 8)


### PR DESCRIPTION
## Summary
- update discard button in `StatsView` to remove screenshots when editing due to OCR errors

## Testing
- `swift --version` *(fails: no such module 'SwiftUI' when trying to build)*

------
https://chatgpt.com/codex/tasks/task_e_687416c3010c832e939572e2e121465b