### PR TITLE
Persist images across app restarts

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/ContentView.swift
@@ -133,6 +133,12 @@ struct ContentView: View {
                     }
                 }
         }
+        .onAppear {
+            photoItems = PhotoPersistence.shared.load()
+        }
+        .onChange(of: photoItems) { newValue in
+            PhotoPersistence.shared.save(newValue)
+        }
         .onChange(of: selectedItems) { _ in
             handleResults(selectedItems)
         }
@@ -260,6 +266,7 @@ struct ContentView: View {
                                 photoItems[index].isAdded = added
                                 photoItems[index].isDuplicate = !added && StatsDatabase.shared.isDuplicate(model)
                             }
+                            PhotoPersistence.shared.save(photoItems)
                         }
                     }
                 } else {
@@ -271,6 +278,7 @@ struct ContentView: View {
             await MainActor.run {
                 selectedItems.removeAll()
             }
+            PhotoPersistence.shared.save(photoItems)
         }
     }
 

--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
@@ -4,8 +4,8 @@ import Photos
 import ImageIO
 
 struct PhotoData: Identifiable {
-    let id = UUID()
-    let item: PhotosPickerItem
+    let id: UUID
+    var item: PhotosPickerItem?
     var image: UIImage?
     var ocrText: String?
     var statsModel: StatsModel?
@@ -18,7 +18,19 @@ struct PhotoData: Identifiable {
     var isDuplicate: Bool = false
 
     init(item: PhotosPickerItem) {
+        self.id = UUID()
         self.item = item
+    }
+
+    init(id: UUID = UUID(), image: UIImage?, ocrText: String?, statsModel: StatsModel?, creationDate: Date?, isAdded: Bool = false, isDuplicate: Bool = false) {
+        self.id = id
+        self.item = nil
+        self.image = image
+        self.ocrText = ocrText
+        self.statsModel = statsModel
+        self.creationDate = creationDate
+        self.isAdded = isAdded
+        self.isDuplicate = isDuplicate
     }
 
     // Cropping ratios based on a 1206x2622 reference screenshot.
@@ -47,6 +59,7 @@ struct PhotoData: Identifiable {
     }
 
     mutating func loadImage() async -> Bool {
+        guard let item = item else { return false }
         if let data = try? await item.loadTransferable(type: Data.self),
            let uiImage = UIImage(data: data) {
             let cropped = crop(uiImage)

--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoPersistence.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoPersistence.swift
@@ -1,0 +1,56 @@
+import Foundation
+import UIKit
+
+struct StoredPhoto: Codable {
+    let id: UUID
+    let imageName: String
+    let ocrText: String?
+    let statsModel: StatsModel?
+    let creationDate: Date?
+    let isAdded: Bool
+    let isDuplicate: Bool
+}
+
+final class PhotoPersistence {
+    static let shared = PhotoPersistence()
+
+    private let imagesDir: URL
+    private let fileURL: URL
+
+    private init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        imagesDir = docs.appendingPathComponent("SavedImages", isDirectory: true)
+        fileURL = docs.appendingPathComponent("photos.json")
+        if !FileManager.default.fileExists(atPath: imagesDir.path) {
+            try? FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+        }
+    }
+
+    func save(_ photos: [PhotoData]) {
+        let records: [StoredPhoto] = photos.compactMap { photo in
+            guard let image = photo.image else { return nil }
+            let name = photo.id.uuidString + ".png"
+            let url = imagesDir.appendingPathComponent(name)
+            if !FileManager.default.fileExists(atPath: url.path) {
+                if let data = image.pngData() {
+                    try? data.write(to: url)
+                }
+            }
+            return StoredPhoto(id: photo.id, imageName: name, ocrText: photo.ocrText, statsModel: photo.statsModel, creationDate: photo.creationDate, isAdded: photo.isAdded, isDuplicate: photo.isDuplicate)
+        }
+        guard let data = try? JSONEncoder().encode(records) else { return }
+        try? data.write(to: fileURL)
+    }
+
+    func load() -> [PhotoData] {
+        guard let data = try? Data(contentsOf: fileURL),
+              let records = try? JSONDecoder().decode([StoredPhoto].self, from: data) else {
+            return []
+        }
+        return records.map { rec in
+            let url = imagesDir.appendingPathComponent(rec.imageName)
+            let image = UIImage(contentsOfFile: url.path)
+            return PhotoData(id: rec.id, image: image, ocrText: rec.ocrText, statsModel: rec.statsModel, creationDate: rec.creationDate, isAdded: rec.isAdded, isDuplicate: rec.isDuplicate)
+        }
+    }
+}

--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -263,6 +263,7 @@ struct StatsView: View {
                 photoData.wrappedValue.isDuplicate = true
             }
             onParseSuccess?()
+            PhotoPersistence.shared.save(photoItems)
         }
     }
 
@@ -303,6 +304,7 @@ struct StatsView: View {
             StatsDatabase.shared.remove(model)
         }
         photoItems.remove(at: indices[currentIndex])
+        PhotoPersistence.shared.save(photoItems)
         dismiss()
     }
 
@@ -316,6 +318,7 @@ struct StatsView: View {
             isDuplicate = true
             photoData.wrappedValue.isDuplicate = true
         }
+        PhotoPersistence.shared.save(photoItems)
     }
 
     private func checkIfAdded() {


### PR DESCRIPTION
## Summary
- make `PhotoData` support creating instances without a `PhotosPickerItem`
- add `PhotoPersistence` helper for saving/loading cropped screenshots
- load saved images on launch and persist any changes
- persist edits and deletes from the stats screen

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6874183236fc832e9ca952459d15b2be