### PR TITLE
Fix onChange compile error

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Models/PhotoData.swift
@@ -3,7 +3,7 @@ import PhotosUI
 import Photos
 import ImageIO
 
-struct PhotoData: Identifiable {
+struct PhotoData: Identifiable, Equatable {
     let id: UUID
     var item: PhotosPickerItem?
     var image: UIImage?
@@ -89,5 +89,17 @@ struct PhotoData: Identifiable {
         } else {
             return false
         }
+    }
+}
+
+extension PhotoData {
+    static func == (lhs: PhotoData, rhs: PhotoData) -> Bool {
+        lhs.id == rhs.id &&
+        lhs.ocrText == rhs.ocrText &&
+        lhs.statsModel == rhs.statsModel &&
+        lhs.creationDate == rhs.creationDate &&
+        lhs.isProcessing == rhs.isProcessing &&
+        lhs.isAdded == rhs.isAdded &&
+        lhs.isDuplicate == rhs.isDuplicate
     }
 }


### PR DESCRIPTION
## Summary
- add `Equatable` conformance to `PhotoData` so `.onChange(of:)` works

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68741b3516b0832e9369d1cb3d7d944b