### PR TITLE
Fix: open error images in view-only mode

### DIFF
--- a/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
+++ b/OCRScreenShotApp/OCRScreenShotApp/Views/StatsView.swift
@@ -176,9 +176,6 @@ struct StatsView: View {
                 }
             } else {
                 checkIfAdded()
-                if photoData.wrappedValue.statsModel?.hasParsingError == true && !isDuplicate {
-                    startEditing()
-                }
             }
         }
         .onChange(of: photoData.wrappedValue.statsModel) { _ in


### PR DESCRIPTION
## Summary
- load error images without automatically jumping into the edit view

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68741947b160832eae0f72789aeee0d5